### PR TITLE
Fix buck build

### DIFF
--- a/libs/utils/WordPressUtils/src/main/AndroidManifest.xml
+++ b/libs/utils/WordPressUtils/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.wordpress.android.util">
+  package="org.wordpress.android.util.local">
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 </manifest>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
@@ -10,6 +10,8 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.wordpress.android.util.local.R;
+
 public class DateTimeUtils {
     private DateTimeUtils() {
         throw new AssertionError();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/NetworkUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/NetworkUtils.java
@@ -8,6 +8,8 @@ import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.provider.Settings;
 
+import org.wordpress.android.util.local.R;
+
 /**
  * requires android.permission.ACCESS_NETWORK_STATE
  */

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PackageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PackageUtils.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
+import org.wordpress.android.util.local.BuildConfig;
+
 public class PackageUtils {
     /**
      * Return true if Debug build. false otherwise.

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -6,7 +6,7 @@ import android.content.res.TypedArray;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.util.TypedValue;
 
-import org.wordpress.android.util.R;
+import org.wordpress.android.util.local.R;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 public class SwipeToRefreshHelper implements OnRefreshListener {


### PR DESCRIPTION
`./buckw build WordPressVanillaDebug`

works as expected now

The issue was that the wordpress utils aar has the same package name as the locally defined lib/utils. Changing the package name of the local dependency fixed the issue
